### PR TITLE
Add support for alpha value (transparency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# color-scales-js
-A utility mimicking Microsoft Excel's Color Scales conditional formatting, which returns the color of a value in a linear gradient between two color endpoints with defined min and max values
+# color-scales
+A utility mimicking Microsoft Excel's Color Scales conditional formatting, which returns the color of a value in a linear gradient between two color endpoints with defined min and max values.
 
 ### [Basic CodePen Demo](https://codepen.io/dalisc/pen/zYoNQge)
 
@@ -27,8 +27,9 @@ The `ColorScale` has the following properties:
 - `max`: The maximum value of the range.
 - `minColor`: The minimum color corresponding to the minimum value.
 - `maxColor`: The maximum color corresponding to the maximum value.
+- `alpha`: The alpha value that indicates the level of transparency/opagueness. E.g. Alpha of 0.8 means 20% transparent. Defaults to 1.
 
-Its constructor is `ColorScale(min, max, minColor, maxColor)`;
+Its constructor is `ColorScale(min, max, minColor, maxColor, alpha)`;
 
 The `ColorScale` class has the following functions:
 
@@ -41,11 +42,12 @@ The `Color` class is an unexported class. It has the following properties:
 - `r`: An integer representing the intensity of the red hue. Ranges from 0 to 255.
 - `g`: An integer representing the intensity of the green hue. Ranges from 0 to 255.
 - `b`: An integer representing the intensity of the blue hue. Ranges from 0 to 255.
+- `a`: The alpha value that indicates the level of transparency/opagueness. E.g. Alpha of 0.8 means 20% transparent. Defaults to 1.
 
 The `Color` class has the following functions:
 
 - `toHexString`: Returns the equivalent hex string representation. The string will be in lower case. Example: "#7f7f7f"
-- `toRGBAString`: Returns the equivalent RGBA string representation. The string will be in lower case. Example: "rgba(127,127,127)"
+- `toRGBAString`: Returns the equivalent RGBA string representation. The string will be in lower case. Example: "rgba(127,127,127, 0.8)"
 
 ### Example Usage
 
@@ -58,17 +60,17 @@ const ColorScales = require("color-scales");
 // Alternatively, import from Skypack, a free CDN for Javascript/TypeScript packages:
 // import ColorScales from "https://cdn.skypack.dev/color-scales";
 
-let colorScale = new ColorScales(min, max, minColor, maxColor);
+let colorScale = new ColorScales(min, max, minColor, maxColor, alpha); // alpha is optional. defaults to 1
  ```
 
-where `min`, `max`, `minColor`, are `maxColor` are replaced by their intended value;
+where `min`, `max`, `minColor`, `maxColor`, and `alpha` are replaced by their intended value;
 
 Example:
 
 ```ts
 const ColorScales = require("color-scales");
 
-let colorScale = new ColorScales(0, 100, "#ffffff", "#000000"); // white to black from 0 to 100
+let colorScale = new ColorScales(0, 100, "#ffffff", "#000000", 0.5); // white to black from 0 to 100 with 50% transparency
 ```
 
 #### Get Color Object
@@ -78,26 +80,47 @@ Example:
 ```ts
 const ColorScales = require("color-scales");
 
-let colorScale = new ColorScales(0, 100, "#ffffff", "#000000"); // red to green from 0 to 100
-let colorObj = colorScale.getColor(50); // returns new Color(127, 127, 127)
+let colorScale = new ColorScales(0, 100, "#ffffff", "#000000", 0.5); // red to green from 0 to 100
+let colorObj = colorScale.getColor(50); // returns new Color(127, 127, 127, 0.5)
 ```
 
 #### Get Hex String
 
-Example:
+Example 1 (full opacity):
 ```ts
 const ColorScales = require("color-scales");
 
-let colorScale = new ColorScales(0, 100, "#ffffff", "#000000");
+let colorScale = new ColorScales(0, 100, "#ffffff", "#000000"); // passing in no alpha value defaults it to 1
 let hexStr = colorScale.getColor(50).toHexString(); // returns "#7f7f7f"
 ```
 
+
+Example 2 (50% transparent):
+```ts
+const ColorScales = require("color-scales");
+
+let colorScale = new ColorScales(0, 100, "#ffffff", "#000000", 0.5);
+let hexStr = colorScale.getColor(50).toHexString(); // returns "#3f3f3f"
+```
+
+
+As this will give a 6-digit hex value that is equivalent to if the transparent color was overlaid on a white background. This package version does not support 8-digit hex values. Thus, if users want to implement true transparency, it is recommended that they use the RGBA string option documented in the next section.
+
 #### Get RGBA String
 
-Example:
+Example 1 (full opacity):
 ```ts
 const ColorScales = require("color-scales");
 
 let colorScale = new ColorScales(0, 100, "#ffffff", "#000000");
 let rgbaStr = colorScale.getColor(50).toRGBAString(); // returns "rgba(127,127,127)"
+```
+
+Example 2 (50% transparent):
+
+```ts
+const ColorScales = require("color-scales");
+
+let colorScale = new ColorScales(0, 100, "#ffffff", "#000000". 0.5);
+let rgbaStr = colorScale.getColor(50).toRGBAString(); // returns "rgba(127,127,127, 0.5)"
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "color-scales",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-scales",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A simple utility mimicking Microsoft Excel's Color Scales conditional formatting, which returns the color of a value in a linear gradient between two color endpoints with defined min and max values.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Color.ts
+++ b/src/Color.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { validateAlphaValue } from './validators';
+
 function componentToHex(c: number) {
   const hex = c.toString(16);
   return hex.length === 1 ? '0' + hex : hex;
@@ -19,6 +21,8 @@ class Color {
   public alpha: number;
 
   constructor(r: number, g: number, b: number, alpha: number = 1) {
+    validateAlphaValue(alpha);
+
     this.r = r;
     this.g = g;
     this.b = b;

--- a/src/Color.ts
+++ b/src/Color.ts
@@ -8,9 +8,9 @@ function componentToHex(c: number) {
 }
 
 function rgbaToHex(color: Color) {
-  const r = Math.floor(color.r * color.alpha);
-  const g = Math.floor(color.g * color.alpha);
-  const b = Math.floor(color.b * color.alpha);
+  const r = Math.floor(color.r * color.a);
+  const g = Math.floor(color.g * color.a);
+  const b = Math.floor(color.b * color.a);
   return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
 }
 
@@ -18,19 +18,19 @@ class Color {
   public r: number;
   public g: number;
   public b: number;
-  public alpha: number;
+  public a: number;
 
-  constructor(r: number, g: number, b: number, alpha: number = 1) {
-    validateAlphaValue(alpha);
+  constructor(r: number, g: number, b: number, a: number = 1) {
+    validateAlphaValue(a);
 
     this.r = r;
     this.g = g;
     this.b = b;
-    this.alpha = alpha;
+    this.a = a;
   }
 
   toRGBAString() {
-    return `rgba(${this.r},${this.g},${this.b},${this.alpha})`;
+    return `rgba(${this.r},${this.g},${this.b},${this.a})`;
   }
 
   toHexString() {

--- a/src/ColorScale.ts
+++ b/src/ColorScale.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import Color = require('./Color');
+import { validateAlphaValue, validateMinMaxColors, validateMinMaxValues } from './validators';
 
 function hexToRgb(hex: string, alpha: number) {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -17,15 +18,9 @@ class ColorScale {
   private maxColor: Color;
 
   constructor(min: number, max: number, minColor: string, maxColor: string, alpha: number = 1) {
-    if (min === max) {
-      throw new Error('The minimum value cannot be equal to the maximum value.');
-    } else if (min > max) {
-      throw new Error('The minimum value must be less than the maximum value.');
-    }
-
-    if (minColor.toUpperCase() === maxColor.toUpperCase()) {
-      throw new Error('The minimum and maximum colors cannot be equal.');
-    }
+    validateMinMaxValues(min, max);
+    validateMinMaxColors(minColor, maxColor);
+    validateAlphaValue(alpha);
 
     this.min = min;
     this.max = max;

--- a/src/__test__/ColorScale.Alpha.test.ts
+++ b/src/__test__/ColorScale.Alpha.test.ts
@@ -5,7 +5,7 @@ import Color = require('../Color');
  * Valid min and max combination, varying alpha
  */
 
- /// min value
+/// min value
 test('Zero alpha should return white color with min value(hex string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(0).toHexString()).toBe('#000000');
 });
@@ -55,7 +55,6 @@ test('Max alpha should return max color with max value(rgba string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#5f5f5f', 1).getColor(100).toRGBAString()).toBe('rgba(95,95,95,1)');
 });
 
-
 /// middle value
 test('Zero alpha should return white color with middle value(hex string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(50).toHexString()).toBe('#000000');
@@ -80,4 +79,3 @@ test('Middle alpha should return correct color with middle value(rgba string)', 
 test('Max alpha should return max color with middle value(rgba string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#5f5f5f', 1).getColor(50).toRGBAString()).toBe('rgba(111,111,111,1)');
 });
-

--- a/src/__test__/ColorScale.Alpha.test.ts
+++ b/src/__test__/ColorScale.Alpha.test.ts
@@ -5,6 +5,7 @@ import Color = require('../Color');
  * Valid min and max combination, varying alpha
  */
 
+ /// min value
 test('Zero alpha should return white color with min value(hex string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(0).toHexString()).toBe('#000000');
 });
@@ -17,6 +18,19 @@ test('Max alpha should return min color with min value(hex string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#000000', 1).getColor(0).toHexString()).toBe('#7f7f7f');
 });
 
+test('Zero alpha should return white color with min value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(0).toRGBAString()).toBe('rgba(127,127,127,0)');
+});
+
+test('Middle alpha should return correct color with min value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#ff0000', '#7f7f7f', 0.5).getColor(0).toRGBAString()).toBe('rgba(255,0,0,0.5)');
+});
+
+test('Max alpha should return min color with min value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#000000', 1).getColor(0).toRGBAString()).toBe('rgba(127,127,127,1)');
+});
+
+/// max value
 test('Zero alpha should return white color with max value(hex string)', () => {
   expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(0).toHexString()).toBe('#000000');
 });
@@ -28,3 +42,42 @@ test('Middle alpha should return correct color with max value(hex string)', () =
 test('Max alpha should return max color with max value(hex string)', () => {
   expect(new ColorScale(0, 100, '#ffffff', '#000000', 1).getColor(100).toHexString()).toBe('#000000');
 });
+
+test('Zero alpha should return white color with max value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(100).toRGBAString()).toBe('rgba(255,255,255,0)');
+});
+
+test('Middle alpha should return correct color with max value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#ff0000', '#7f7f7f', 0.5).getColor(100).toRGBAString()).toBe('rgba(127,127,127,0.5)');
+});
+
+test('Max alpha should return max color with max value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#5f5f5f', 1).getColor(100).toRGBAString()).toBe('rgba(95,95,95,1)');
+});
+
+
+/// middle value
+test('Zero alpha should return white color with middle value(hex string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(50).toHexString()).toBe('#000000');
+});
+
+test('Middle alpha should return correct color with middle value(hex string)', () => {
+  expect(new ColorScale(0, 100, '#000000', '#0000ff', 0.5).getColor(50).toHexString()).toBe('#00003f');
+});
+
+test('Max alpha should return correct color with middle value(hex string)', () => {
+  expect(new ColorScale(0, 100, '#ffffff', '#000000', 1).getColor(50).toHexString()).toBe('#7f7f7f');
+});
+
+test('Zero alpha should return white color with middle value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#ffffff', 0).getColor(50).toRGBAString()).toBe('rgba(191,191,191,0)');
+});
+
+test('Middle alpha should return correct color with middle value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#ff0000', '#7f7f7f', 0.5).getColor(50).toRGBAString()).toBe('rgba(191,63,63,0.5)');
+});
+
+test('Max alpha should return max color with middle value(rgba string)', () => {
+  expect(new ColorScale(0, 100, '#7f7f7f', '#5f5f5f', 1).getColor(50).toRGBAString()).toBe('rgba(111,111,111,1)');
+});
+

--- a/src/__test__/ColorScale.Color.test.ts
+++ b/src/__test__/ColorScale.Color.test.ts
@@ -35,33 +35,32 @@ test('Value greater than max value should return max color (Color object)', () =
   expect(minColor).toStrictEqual(expectedColor);
 });
 
-
 /**
  * Color to RGBA string
  */
 test('Color object with no alpha value should convert to correct RGBA string with alpha value of 1', () => {
-  const color = new Color(81,12,33);
+  const color = new Color(81, 12, 33);
   const expectedRGBAString = 'rgba(81,12,33,1)';
   expect(color.toRGBAString()).toBe(expectedRGBAString);
-})
+});
 
 test('Color object with specified alpha value should convert to correct RGBA string', () => {
-  const color = new Color(81,12,33, 0.7);
+  const color = new Color(81, 12, 33, 0.7);
   const expectedRGBAString = 'rgba(81,12,33,0.7)';
   expect(color.toRGBAString()).toBe(expectedRGBAString);
-})
+});
 
 /**
  * Color to Hex string
  */
 test('Color object with no alpha value should convert to correct hex string with alpha value of 1', () => {
-  const color = new Color(81,12,33);
+  const color = new Color(81, 12, 33);
   const expectedRGBAString = '#510c21';
   expect(color.toHexString()).toBe(expectedRGBAString);
-})
+});
 
 test('Color object with specified alpha value should convert to correct hex string', () => {
-  const color = new Color(81,12,33, 0.7);
+  const color = new Color(81, 12, 33, 0.7);
   const expectedRGBAString = '#380817';
   expect(color.toHexString()).toBe(expectedRGBAString);
-})
+});

--- a/src/__test__/ColorScale.Color.test.ts
+++ b/src/__test__/ColorScale.Color.test.ts
@@ -54,13 +54,13 @@ test('Color object with specified alpha value should convert to correct RGBA str
 /**
  * Color to Hex string
  */
-test('Color object with no alpha value should convert to correct RGBA string with alpha value of 1', () => {
+test('Color object with no alpha value should convert to correct hex string with alpha value of 1', () => {
   const color = new Color(81,12,33);
   const expectedRGBAString = '#510c21';
   expect(color.toHexString()).toBe(expectedRGBAString);
 })
 
-test('Color object with specified alpha value should convert to correct RGBA string', () => {
+test('Color object with specified alpha value should convert to correct hex string', () => {
   const color = new Color(81,12,33, 0.7);
   const expectedRGBAString = '#380817';
   expect(color.toHexString()).toBe(expectedRGBAString);

--- a/src/__test__/ColorScale.Color.test.ts
+++ b/src/__test__/ColorScale.Color.test.ts
@@ -34,3 +34,34 @@ test('Value greater than max value should return max color (Color object)', () =
   const expectedColor = new Color(255, 255, 255);
   expect(minColor).toStrictEqual(expectedColor);
 });
+
+
+/**
+ * Color to RGBA string
+ */
+test('Color object with no alpha value should convert to correct RGBA string with alpha value of 1', () => {
+  const color = new Color(81,12,33);
+  const expectedRGBAString = 'rgba(81,12,33,1)';
+  expect(color.toRGBAString()).toBe(expectedRGBAString);
+})
+
+test('Color object with specified alpha value should convert to correct RGBA string', () => {
+  const color = new Color(81,12,33, 0.7);
+  const expectedRGBAString = 'rgba(81,12,33,0.7)';
+  expect(color.toRGBAString()).toBe(expectedRGBAString);
+})
+
+/**
+ * Color to Hex string
+ */
+test('Color object with no alpha value should convert to correct RGBA string with alpha value of 1', () => {
+  const color = new Color(81,12,33);
+  const expectedRGBAString = '#510c21';
+  expect(color.toHexString()).toBe(expectedRGBAString);
+})
+
+test('Color object with specified alpha value should convert to correct RGBA string', () => {
+  const color = new Color(81,12,33, 0.7);
+  const expectedRGBAString = '#380817';
+  expect(color.toHexString()).toBe(expectedRGBAString);
+})

--- a/src/__test__/ColorScale.Color.test.ts
+++ b/src/__test__/ColorScale.Color.test.ts
@@ -64,3 +64,18 @@ test('Color object with specified alpha value should convert to correct hex stri
   const expectedRGBAString = '#380817';
   expect(color.toHexString()).toBe(expectedRGBAString);
 });
+
+/**
+ * Alpha input
+ */
+test('Error thrown when alpha value is less than 0', () => {
+  expect(() => new Color(12, 123, 4, -0.6)).toThrow('The alpha value must be between 0 and 1.');
+});
+
+test('Error thrown when alpha value is more than 1', () => {
+  expect(() => new Color(12, 123, 4, 2)).toThrow('The alpha value must be between 0 and 1.');
+});
+
+test('No error thrown when alpha value is between 0 and 1', () => {
+  expect(() => new Color(12, 123, 4, 0.7)).not.toThrow();
+});

--- a/src/__test__/ColorScale.test.ts
+++ b/src/__test__/ColorScale.test.ts
@@ -20,3 +20,18 @@ test('Error thrown when min value is greater than max value', () => {
 test('Error thrown when min color is equal to max color', () => {
   expect(() => new ColorScale(0, 100, '#E4E4E4', '#e4e4e4')).toThrow('The minimum and maximum colors cannot be equal.');
 });
+
+/**
+ * Alpha input
+ */
+test('Error thrown when alpha value is less than 0', () => {
+  expect(() => new ColorScale(0, 100, '#E4E4E4', '#000000', -0.6)).toThrow('The alpha value must be between 0 and 1.');
+});
+
+test('Error thrown when alpha value is more than 1', () => {
+  expect(() => new ColorScale(0, 100, '#E4E4E4', '#000000', 2)).toThrow('The alpha value must be between 0 and 1.');
+});
+
+test('No error thrown when alpha value is between 0 and 1', () => {
+  expect(() => new ColorScale(0, 100, '#E4E4E4', '#000000', 0.7)).not.toThrow();
+});

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,0 +1,21 @@
+import Color = require('./Color');
+
+export function validateMinMaxValues(min: number, max: number) {
+  if (min === max) {
+    throw new Error('The minimum value cannot be equal to the maximum value.');
+  } else if (min > max) {
+    throw new Error('The minimum value must be less than the maximum value.');
+  }
+}
+
+export function validateMinMaxColors(minColor: string, maxColor: string) {
+  if (minColor.toUpperCase() === maxColor.toUpperCase()) {
+    throw new Error('The minimum and maximum colors cannot be equal.');
+  }
+}
+
+export function validateAlphaValue(alpha: number) {
+  if (alpha < 0 || alpha > 1) {
+    throw new Error('The alpha value must be between 0 and 1.');
+  }
+}


### PR DESCRIPTION
- ColorScale and Color take in an optional alpha value in the constructor (defaults to 1 if no argument is passed in).
- Change RGB string to RGBA. Users are able to use transparency with the RGBA string, but not hex string as 8-digit hex not supported.
- Add validation for alpha value
- Add testing for alpha value
- Add testing for RGBA string and hex string conversions